### PR TITLE
RDKE-622 Fix warnings in tr69hostif

### DIFF
--- a/src/hostif/profiles/STBService/Components_XrdkSDCard.cpp
+++ b/src/hostif/profiles/STBService/Components_XrdkSDCard.cpp
@@ -805,6 +805,8 @@ bool getSDCardProperties(strMgrSDcardPropParam_t *sdCardParam)
 			}
                         break;
 			}
+		    case SD_Capacity:
+			break;
 		    case SD_CardFailed:
 			break;
 		    case SD_LifeElapsed:
@@ -838,6 +840,8 @@ bool getSDCardProperties(strMgrSDcardPropParam_t *sdCardParam)
 				ERR_CHK(safec_rc);
 			}
                 	break;
+	     case SD_Capacity:
+		break;
 	     case SD_CardFailed:
 		break;
 	     case SD_LifeElapsed:


### PR DESCRIPTION
Reason for change: Improve tr69hostif module code stability - Fix warnings in tr69hostif
Test Procedure: Sanity, functionality tests
Risks: None
Priority: P2
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)