### PR TITLE
RDK-56223 : Define tr181 parameter and handlers for the IUI Version

### DIFF
--- a/src/hostif/handlers/src/hostIf_DeviceClient_ReqHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_DeviceClient_ReqHandler.cpp
@@ -290,6 +290,10 @@ int DeviceClientReqHandler::handleSetMsg(HOSTIF_MsgData_t *stMsgData)
         {
             ret = pIface->set_Device_DeviceInfo_X_RDKCENTRAL_COM_FirmwareDownloadDeferReboot(stMsgData);
         }
+        else if (!strcasecmp(stMsgData->paramName, IUI_VERSION))
+        {
+            ret = pIface->set_Device_DeviceInfo_IUI_Version(stMsgData);
+        }
         else
         {
             ret = NOK;
@@ -516,6 +520,14 @@ int DeviceClientReqHandler::handleGetMsg(HOSTIF_MsgData_t *stMsgData)
         else if (strcasecmp(stMsgData->paramName,"Device.DeviceInfo.SoftwareVersion") == 0)
         {
             ret = pIface->get_Device_DeviceInfo_SoftwareVersion(stMsgData);
+        }
+        else if (strcasecmp(stMsgData->paramName,"Device.DeviceInfo.MigrationPreparer.MigrationReady") == 0)
+        {
+            ret = pIface->get_Device_DeviceInfo_MigrationPreparer_MigrationReady(stMsgData);
+        }
+        else if (strcasecmp(stMsgData->paramName,IUI_VERSION) == 0)
+        {
+            ret = pIface->get_Device_DeviceInfo_IUI_Version(stMsgData);
         }
         else if (strcasecmp(stMsgData->paramName,"Device.DeviceInfo.AdditionalHardwareVersion") == 0)
         {

--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -4366,5 +4366,13 @@
         </syntax>
       </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM.IUI." access="readOnly" minEntries="0" maxEntries="1">
+      <parameter base="Version" access="readOnly" notification="0" maxNotification="2" >
+        <syntax>
+          <string/>
+          <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+    </object>
   </model>
 </dm:document>

--- a/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.cpp
+++ b/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.cpp
@@ -102,6 +102,7 @@
 #define XRE_CONTAINER_SUPPORT_STATUS_FILE  "/opt/XRE_container_enable"
 #define IPREMOTE_INTERFACE_INFO            "/tmp/ipremote_interface_info"
 #define MODEL_NAME_FILE                    "/tmp/.model"
+#define IUI_VERSION_FILE                   "/tmp/.iuiVersion"
 #define PREVIOUS_REBOT_REASON_FILE         "/opt/secure/reboot/previousreboot.info"
 #define NTPENABLED_FILE                    "/opt/.ntpEnabled"
 #define RDKV_DAB_ENABLE_FILE               "/opt/dab-enable"
@@ -2090,6 +2091,71 @@ int hostIf_DeviceInfo::get_X_RDKCENTRAL_COM_BootTime(HOSTIF_MsgData_t * stMsgDat
     stMsgData->paramtype = hostIf_UnsignedIntType;
     stMsgData->paramLen = sizeof(hostIf_UnsignedIntType);
     return ret;
+}
+
+int hostIf_DeviceInfo::get_Device_DeviceInfo_IUI_Version(HOSTIF_MsgData_t * stMsgData, bool *pChanged)
+{
+    int ret=NOT_HANDLED;
+    stMsgData->paramtype = hostIf_StringType;
+
+    std::string iuiVersion;
+    std::ifstream file(IUI_VERSION_FILE);
+
+    if (!file.is_open()) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s:%s:%d] Failed to open IUI Version file\n!", __FUNCTION__, __FILE__, __LINE__);
+        return NOK;
+    }
+
+    if (std::getline(file, iuiVersion)) {
+        // Remove newline char if any in iui version
+        if (!iuiVersion.empty() && iuiVersion.back() == '\n') {
+            iuiVersion.pop_back();
+        }
+
+        RDK_LOG(RDK_LOG_DEBUG, LOG_TR69HOSTIF, "[%s:%s:%d] iuiVersion = %s.\n", __FUNCTION__, __FILE__, __LINE__, iuiVersion.c_str());
+        strncpy((char *)stMsgData->paramValue, iuiVersion.c_str(), sizeof(stMsgData->paramValue)-1);
+        stMsgData->paramValue[sizeof(stMsgData->paramValue)-1] = '\0';
+        stMsgData->paramLen = iuiVersion.length();
+
+        RDK_LOG(RDK_LOG_DEBUG, LOG_TR69HOSTIF, "[%s:%s:%d] paramValue: %s stMsgData->paramLen: %d \n", __FUNCTION__, __FILE__, __LINE__, stMsgData->paramValue, stMsgData->paramLen);
+        ret = OK;
+    } else {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "%s(): Failed to read iui version.\n", __FUNCTION__);
+    }
+
+    file.close();
+
+    RDK_LOG(RDK_LOG_TRACE1,LOG_TR69HOSTIF,"[%s()]\n", __FUNCTION__);
+    return ret;
+
+}
+
+int hostIf_DeviceInfo::set_Device_DeviceInfo_IUI_Version(HOSTIF_MsgData_t *stMsgData)
+{
+    std::string iuiVersion = getStringValue(stMsgData);
+
+    if (iuiVersion.empty()) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s:%s:%d] Empty IUI Version provided\n", __FUNCTION__, __FILE__, __LINE__);
+        return NOK;
+    }
+
+    std::ofstream file(IUI_VERSION_FILE);
+    if (!file.is_open()) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s:%s:%d] Failed to open IUI Version file for writing\n", __FUNCTION__, __FILE__, __LINE__);
+        return NOK;
+    }
+
+    file << iuiVersion;
+
+    if (file.fail()) {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s:%s:%d] Failed to write IUI Version to file\n", __FUNCTION__, __FILE__, __LINE__);
+        file.close();
+        return NOK;
+    }
+
+    RDK_LOG(RDK_LOG_DEBUG, LOG_TR69HOSTIF, "[%s:%s:%d] Successfully wrote IUI Version: %s\n", __FUNCTION__, __FILE__, __LINE__, iuiVersion.c_str());
+    file.close();
+    return OK;
 }
 
 int hostIf_DeviceInfo::set_Device_DeviceInfo_X_RDKCENTRAL_COM_PreferredGatewayType(HOSTIF_MsgData_t *stMsgData)

--- a/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.h
+++ b/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.h
@@ -178,6 +178,7 @@
 #define PARTNER_ID                                      "Device.DeviceInfo.X_RDKCENTRAL-COM_Syndication.PartnerId"
 
 #define FWDNLD_DEFER_REBOOT                             "Device.DeviceInfo.X_RDKCENTRAL-COM_FirmwareDownloadDeferReboot"
+#define IUI_VERSION                                     "Device.DeviceInfo.X_RDKCENTRAL-COM.IUI.Version"
 
 /* Profile: X_RDKCENTRAL-COM_RDKRemoteDebugger */
 #ifdef USE_REMOTE_DEBUGGER
@@ -511,6 +512,25 @@ public:
      * @see get_Device_DeviceInfo_ProductClass.
      */
     int get_Device_DeviceInfo_SoftwareVersion(HOSTIF_MsgData_t *, bool *pChanged = NULL);
+
+    /**
+    * @brief get_Device_DeviceInfo_IUI_Version.
+    *
+    * This function provides the IUI version
+    * The component name (human readable string).
+    *
+    * @return The status of the operation.
+    *
+    * @retval OK if get_Device_DeviceInfo_IUI_Version was successfully fetched.
+    :1
+   * @retval ERR_INTERNAL_ERROR if not able to fetch from device.
+    *
+    * @sideeffect All necessary structures and buffers are deallocated.
+    * @execution Synchronous.
+    *
+    * @see get_Device_DeviceInfo_IUI_Version.
+    */
+   int get_Device_DeviceInfo_IUI_Version(HOSTIF_MsgData_t *, bool *pChanged = NULL);
 
     /**
      * @brief get_Device_DeviceInfo_AdditionalHardwareVersion.
@@ -1001,6 +1021,7 @@ public:
     int set_Device_DeviceInfo_X_RDKCENTRAL_COM_PreferredGatewayType(HOSTIF_MsgData_t *);
     int set_Device_DeviceInfo_X_RDKCENTRAL_COM_FirmwareDownloadUseCodebig(HOSTIF_MsgData_t *);
     int set_Device_DeviceInfo_X_RDKCENTRAL_COM_FirmwareDownloadDeferReboot(HOSTIF_MsgData_t *);
+    int set_Device_DeviceInfo_IUI_Version(HOSTIF_MsgData_t *);
 
     /**
     * @brief set_xOpsDMUploadLogsNow.


### PR DESCRIPTION
Reason for change: Define tr181 parameter and handlers for the IUI Version
Test Procedure: Verify tr181 get and set
Risks: Low
Priority: P1

Change-Id: Iadedef3035fcbfaae1fe1c1bee52003076879536