### PR TITLE
RDKE-697: [MEMCR] AppHibernate RFC XML tags are missed in data-model.xml

### DIFF
--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -4373,6 +4373,14 @@
           <default type="factory" value="false"/>
         </syntax>
       </parameter>
-    </object>  
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppHibernate." access="readOnly" minEntries="0" maxEntries="1" >
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+        <syntax>
+          <boolean/>
+          <default type="factory" value="false"/>
+        </syntax>
+      </parameter>
+    </object>
   </model>
 </dm:document>


### PR DESCRIPTION
Reason for change: Added the AppHibernate RFC XML tags in data-model-generic.xml.
Test Procedure: Build and verify.
Risks: Medium.
Signed-off-by: sundaramuneeswaran_muthuraj@comcast.com