### PR TITLE
RDKVREFPLT-4470:Enable https for webpa.rdkcentral.com

### DIFF
--- a/partners_defaults.json
+++ b/partners_defaults.json
@@ -57,7 +57,7 @@
         "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.LSA.PSNUrl" : "",
         "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.XDial.AppList" : "",
         "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.MTLS.mTlsCrashdumpUpload.Enable" : "false",
-        "Device.X_RDK_WebPA_Server.URL" : "",
+        "Device.X_RDK_WebPA_Server.URL" : "https://webpa.rdkcentral.com:8080",
         "Device.X_RDK_WebPA_TokenServer.URL" : "",
         "Device.X_RDK_WebPA_DNSText.URL" : "",
         "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.CrashportalEndpoint.Enable" : "true",


### PR DESCRIPTION
Reason for change: Modified partner_default json for webpa
 Test Procedure: Build should pass
Risks: Low
Signed-off-by:Lakshmipriya_Purushan@comcast.com