### PR TITLE
RDKEMW-2621:Default ReserveTTS RFC to true

### DIFF
--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -4320,7 +4320,7 @@
       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
         <syntax>
           <boolean/>
-          <default type="factory" value="false"/>
+          <default type="factory" value="true"/>
         </syntax>
       </parameter>
     </object>


### PR DESCRIPTION
Reason for change: Default ReserveTTS rfc to true across devices
Test Procedure: as per RDKEMW-2621
Priority: P1
Risks: Low
Signed-off-by: Tony Paul <Tony_Paul@comcast.com>