### PR TITLE
RDKEMW-4334-InactiveApplications- tr181 parameter does not exist in data model

### DIFF
--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -4439,6 +4439,13 @@
           <string/>
         </syntax>
       </parameter>
-    </object>    
+    </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.InactiveApplications." access="readOnly" minEntries="0" maxEntries="1">
+      <parameter base="Maximum" access="readWrite" notification="0" maxNotification="2" >
+        <syntax>
+          <unsignedInt/>
+        </syntax>
+      </parameter>
+    </object> 
   </model>
 </dm:document>


### PR DESCRIPTION
RDKEMW-4334
-InactiveApplications- tr181 parameter does not exist in data model
Reason for change: To bring in the parameter in data-model
Test Procedure: 
 
Risks: Medium
Priority: P1
 
Signed-off-by: Vismal S Kumar <ajvismal@yahoo.com>