### PR TITLE
RDKTV-36715: Logs flooding issue observed in tr69hostif.log "refreshInterfaceName:"

### DIFF
--- a/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
+++ b/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
@@ -859,6 +859,7 @@ void getIPInterfaceIDs(int *ifindexes) {
             char buffer[64];
             if (fgets(buffer, sizeof(buffer), ifindex_fp)) {
                 ifindexes[count++] = atoi(buffer);
+                RDK_LOG(RDK_LOG_INFO,LOG_TR69HOSTIF,"%s:%d ARAVINDAN put ifindex : %d\n", __FILE__, __LINE__, ifindexes[count-1]);
             }
             pclose(ifindex_fp);
         }
@@ -892,6 +893,7 @@ int hostif_InterfaceStack::getIPInterfaces(IPInterfacesMap_t& interfaceList)
         for(ipIndex=0; ipIndex < ipNumOfEntries; ipIndex++)
         {
             std::string ipIfName;
+            RDK_LOG(RDK_LOG_INFO,LOG_TR69HOSTIF,"%s:%d ARAVINDAN get ifindex : %d\n", __FILE__, __LINE__, ifindexes[ipIndex]);
             hostIf_IPInterface *pIface = hostIf_IPInterface::getInstance(ifindexes[ipIndex]);
 
             if(!pIface)

--- a/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
+++ b/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
@@ -889,7 +889,7 @@ int hostif_InterfaceStack::getIPInterfaces(IPInterfacesMap_t& interfaceList)
         int ifindexes[32];
         getIPInterfaceIDs(ifindexes);
 
-        for(ipIndex=0; ipIndex <= ipNumOfEntries; ipIndex++)
+        for(ipIndex=0; ipIndex < ipNumOfEntries; ipIndex++)
         {
             std::string ipIfName;
             hostIf_IPInterface *pIface = hostIf_IPInterface::getInstance(ifindexes[ipIndex]);

--- a/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
+++ b/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
@@ -49,6 +49,7 @@
 #define MAX_CMD_LEN 256
 #define MAX_IFNAME_LEN 64
 #define SYS_CLASS_NET_PATH  "/sys/class/net/"
+#define MAX_IFCS 256
 
 #define IN
 #define OUT
@@ -886,10 +887,10 @@ int hostif_InterfaceStack::getIPInterfaces(IPInterfacesMap_t& interfaceList)
         ipNumOfEntries=get_int(msgData.paramValue);
         RDK_LOG(RDK_LOG_DEBUG,LOG_TR69HOSTIF,"%s:%d ipNumOfEntries = %d\n", __FUNCTION__, __LINE__, ipNumOfEntries);
 
-        int ifindexes[32];
+        int ifindexes[MAX_IFCS];
         getIPInterfaceIDs(ifindexes);
 
-        for(ipIndex=0; ipIndex < ipNumOfEntries; ipIndex++)
+        for(ipIndex=0; ipIndex < ipNumOfEntries && ipIndex < MAX_IFCS; ipIndex++)
         {
             std::string ipIfName;
             hostIf_IPInterface *pIface = hostIf_IPInterface::getInstance(ifindexes[ipIndex]);
@@ -908,6 +909,9 @@ int hostif_InterfaceStack::getIPInterfaces(IPInterfacesMap_t& interfaceList)
                 ipIfName.append(msgData.paramValue);
                 interfaceList.insert( std::pair<std::string, int>(ipIfName, ipIndex));
             }
+        }
+        if (ipIndex >= MAX_IFCS) {
+            RDK_LOG(RDK_LOG_WARN,LOG_TR69HOSTIF,"%s:%d Available interfaces exceeds max no. of interfaces (%d)\n", __FILE__, __LINE__, MAX_IFCS);
         }
     }
     return(rc);

--- a/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
+++ b/src/hostif/profiles/InterfaceStack/Device_InterfaceStack.cpp
@@ -859,7 +859,6 @@ void getIPInterfaceIDs(int *ifindexes) {
             char buffer[64];
             if (fgets(buffer, sizeof(buffer), ifindex_fp)) {
                 ifindexes[count++] = atoi(buffer);
-                RDK_LOG(RDK_LOG_INFO,LOG_TR69HOSTIF,"%s:%d ARAVINDAN put ifindex : %d\n", __FILE__, __LINE__, ifindexes[count-1]);
             }
             pclose(ifindex_fp);
         }
@@ -893,7 +892,6 @@ int hostif_InterfaceStack::getIPInterfaces(IPInterfacesMap_t& interfaceList)
         for(ipIndex=0; ipIndex < ipNumOfEntries; ipIndex++)
         {
             std::string ipIfName;
-            RDK_LOG(RDK_LOG_INFO,LOG_TR69HOSTIF,"%s:%d ARAVINDAN get ifindex : %d\n", __FILE__, __LINE__, ifindexes[ipIndex]);
             hostIf_IPInterface *pIface = hostIf_IPInterface::getInstance(ifindexes[ipIndex]);
 
             if(!pIface)


### PR DESCRIPTION
Reason for change: Populate list only with IDs which are present in /sys/class/net/interfaces 
Test Procedure: Build RDKE image and check logs
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)