### PR TITLE
RDKTV-36715: Logs flooding issue observed in tr69hostif.log

### DIFF
--- a/src/hostif/handlers/src/hostIf_IPClient_ReqHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_IPClient_ReqHandler.cpp
@@ -429,7 +429,7 @@ void IPClientReqHandler::registerUpdateCallback(updateCallback cb)
     mUpdateCallback = cb;
 }
 
-void getIPIfcIDs(int *ifindexes) {
+void getIPIfcIDs(unsigned int *ifindexes) {
     int count = 0;
     FILE *fp = v_secure_popen("r", "ls /sys/class/net");
     if (!fp) {
@@ -481,7 +481,7 @@ void IPClientReqHandler::checkForUpdates()
         sendAddRemoveEvents (mUpdateCallback, interfaceNumberOfEntries, curNumOfIPInterface, objectPath);
     }
 
-    int ifindexes[MAX_IFCS];
+    unsigned int ifindexes[MAX_IFCS];
     getIPIfcIDs(ifindexes);
     for (int i = 0; i < interfaceNumberOfEntries && i < MAX_IFCS; i++)
     {


### PR DESCRIPTION
Reason for change: Fix build error
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)