### PR TITLE
RDK-57868 : Default IPControl RFC for EU partners

### DIFF
--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -224,13 +224,13 @@
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.IPControl." access="readOnly" minEntries="1" maxEntries="1" />
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.IPControl.Service." access="readOnly" minEntries="1" maxEntries="1" />
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.IPControl.Service.Discovery." access="readOnly" minEntries="1" maxEntries="1" >
-      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+      <parameter base="Enable" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" >
         <syntax> <boolean/> </syntax>
       </parameter>
     </object>
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.IPControl.Subsystem." access="readOnly" minEntries="1" maxEntries="1" />
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.IPControl.Subsystem.RICS." access="readOnly" minEntries="1" maxEntries="1" >
-      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+      <parameter base="Enable" bsUpdate="allUpdate" access="readWrite" notification="0" maxNotification="2" >
         <syntax> <boolean/> </syntax>
       </parameter>
     </object>


### PR DESCRIPTION
Reason for change: Set default value to IPControl parameters
Test Procedure: Verify with tr181 get
Risks: Low
Priority: P1