### PR TITLE
RDK-58526 : Default IPControl RFC for EU partners

### DIFF
--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -511,6 +511,14 @@
         </syntax>
       </parameter>
     </object>
+     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.apps." access="readOnly" minEntries="0" maxEntries="1" >
+      <parameter base="watchdogmode" access="readWrite" notification="0" maxNotification="2" >
+        <syntax>
+           <boolean/>
+             <default type="factory" value=""/>
+        </syntax>
+      </parameter>
+     </object>
      <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_xOpsDeviceMgmt.ForwardSSH." access="readOnly" minEntries="0" maxEntries="unbounded" >
        <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
          <syntax>


### PR DESCRIPTION
Reason for change: Set default value to Apps parameters
Test Procedure: Verify with tr181 get
Risks: Low
Priority: P1