### PR TITLE
RDKEMW-4344 : Include the missed RFCs in RDKE.

### DIFF
--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -358,6 +358,14 @@
        </syntax>
       </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BTR.DebugMode." access="readOnly" minEntries="1" maxEntries="1" >
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+       <syntax>
+         <boolean/>
+          <default type="factory" value="false"/>
+       </syntax>
+      </parameter>
+    </object>
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.BTSplitAudio." access="readOnly" minEntries="0" maxEntries="1" >
       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
         <syntax>

--- a/src/hostif/parodusClient/waldb/data-model/data-model-stb.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-stb.xml
@@ -461,6 +461,14 @@
         </syntax>
       </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.TR069support." access="readOnly" minEntries="1" maxEntries="1" >
+      <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+        <syntax>
+           <boolean/>
+      <default type="factory" value="false"/>
+        </syntax>
+      </parameter>
+    </object>
     <object base="Device.Services.STBService.1.Capabilities.VideoDecoder.X_RDKCENTRAL-COM_MPEGHPart2." access="readOnly" minEntries="1" maxEntries="1" >
       <parameter base="ProfileLevelNumberOfEntries" access="readOnly"  notification="0" maxNotification="2" >
         <syntax>

--- a/src/hostif/parodusClient/waldb/data-model/data-model-tv.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-tv.xml
@@ -390,6 +390,14 @@
          </syntax>
        </parameter>
     </object>
+    <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.TR069support." access="readOnly"  minEntries="1" maxEntries="1" >
+       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
+         <syntax>
+           <boolean/>
+           <default type="factory" value="false"/>
+         </syntax>
+       </parameter>
+    </object>
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature." access="readOnly" minEntries="1" maxEntries="1" />
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature." access="readOnly" minEntries="1" maxEntries="1" />
     <object base="Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature." access="readOnly" minEntries="1" maxEntries="1">


### PR DESCRIPTION
Reason for change:
Include DebugMode and TR069support RFC's with default valuse as false.

Priority: P1
Test Procedure: Follow the steps provided in description.

Risks: Low
Signed-off-by:Natraj Muthusamy <Natraj_Muthusamy@comcast.com>