### PR TITLE
RDKEMW-6520: tr69hostif service starts before iarmbusd

### DIFF
--- a/tr69hostif.service
+++ b/tr69hostif.service
@@ -18,7 +18,7 @@
 ##########################################################################
 [Unit]
 Description=TR69 Host Interface Daemon
-After=lighttpd.service securemount.service
+After=lighttpd.service securemount.service iarmbusd.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Reason for change: iarmbusd.service is required before tr69hostif for IARM calls to succeed
Test Procedure: Build RDKE image
Risks: Low

Signed-off-by: Aravindan NC [nc.aravindan@gmail.com](mailto:nc.aravindan@gmail.com)