### PR TITLE
[RDKEMW-5582] -[RDKE] tr69hostif.log contains any garbage data for the paramValue field

### DIFF
--- a/src/hostif/handlers/include/hostIf_msgHandler.h
+++ b/src/hostif/handlers/include/hostIf_msgHandler.h
@@ -98,6 +98,8 @@ void hostIf_Print_msgData(HOSTIF_MsgData_t *stMsgData);
 
 void hostIf_Free_stMsgData (HOSTIF_MsgData_t *stMsgData);
 
+void paramValueToString(const HOSTIF_MsgData_t *stMsgData, char *paramValueStr, size_t strSize);
+
 bool hostIf_initalize_ConfigManger();
 bool hostIf_ConfigProperties_Init();
 class msgHandler {

--- a/src/hostif/handlers/src/hostIf_msgHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_msgHandler.cpp
@@ -82,6 +82,8 @@ static std::atomic<bool> loggedGet1000Within5Min {false};
 static std::atomic<bool> loggedSet200Within1Min {false};
 static std::atomic<bool> loggedSet1000Within5Min {false};
 
+#define PARAM_VALUE_STR_SIZE 128
+
 int hostIf_GetMsgHandler(HOSTIF_MsgData_t *stMsgData)
 {
     LOG_ENTRY_EXIT;
@@ -137,40 +139,42 @@ int hostIf_GetMsgHandler(HOSTIF_MsgData_t *stMsgData)
             ret = pMsgHandler->handleGetMsg(stMsgData);
             auto endTime = std::chrono::high_resolution_clock::now();
             auto timeTaken = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
-            char paramValueStr[128] = {0};
+            char paramValueStr[PARAM_VALUE_STR_SIZE] = {0};
             switch (stMsgData->paramtype) {
             case hostIf_StringType:
-                snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
+                snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%s", stMsgData->paramValue);
+                //snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
                 break;
             case hostIf_IntegerType: {
                  int val = 0;
                  memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, sizeof(paramValueStr), "%d", val);
+                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%d", val);
                  break;
             }
             case hostIf_UnsignedIntType: {
                  unsigned int val = 0;
                  memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, sizeof(paramValueStr), "%u", val);
+                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%u", val);
                  break;
             }
             case hostIf_BooleanType: {
                  bool val = false;
                  memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, sizeof(paramValueStr), "%s", val ? "true" : "false");
+                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%s", val ? "true" : "false");
                 break;
             }
             case hostIf_DateTimeType:
-                 snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
+                 //snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
+                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%s", stMsgData->paramValue);
                  break;
             case hostIf_UnsignedLongType: {
                  unsigned long val = 0;
                  memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, sizeof(paramValueStr), "%lu", val);
+                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%lu", val);
                  break;
             }
             default:
-                   snprintf(paramValueStr, sizeof(paramValueStr), "<unknown or unsupported type>");
+                   snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "<unknown or unsupported type>");
                    break;
             }
 

--- a/src/hostif/handlers/src/hostIf_msgHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_msgHandler.cpp
@@ -137,13 +137,51 @@ int hostIf_GetMsgHandler(HOSTIF_MsgData_t *stMsgData)
             ret = pMsgHandler->handleGetMsg(stMsgData);
             auto endTime = std::chrono::high_resolution_clock::now();
             auto timeTaken = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
+            char paramValueStr[128] = {0};
+            switch (stMsgData->paramtype) {
+            case hostIf_StringType:
+                snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+                break;
+            case hostIf_IntegerType: {
+                 int val = 0;
+                 memcpy(&val, stMsgData->paramValue, sizeof(val));
+                 snprintf(paramValueStr, sizeof(paramValueStr), "%d", val);
+                 break;
+            }
+            case hostIf_UnsignedIntType: {
+                 unsigned int val = 0;
+                 memcpy(&val, stMsgData->paramValue, sizeof(val));
+                 snprintf(paramValueStr, sizeof(paramValueStr), "%u", val);
+                 break;
+            }
+            case hostIf_BooleanType: {
+                 bool val = false;
+                 memcpy(&val, stMsgData->paramValue, sizeof(val));
+                 snprintf(paramValueStr, sizeof(paramValueStr), "%s", val ? "true" : "false");
+                break;
+            }
+            case hostIf_DateTimeType:
+                 snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+                 break;
+            case hostIf_UnsignedLongType: {
+                 unsigned long val = 0;
+                 memcpy(&val, stMsgData->paramValue, sizeof(val));
+                 snprintf(paramValueStr, sizeof(paramValueStr), "%lu", val);
+                 break;
+            }
+            default:
+                   snprintf(paramValueStr, sizeof(paramValueStr), "<unknown or unsupported type>");
+                   break;
+            }
+
+            
 
             // Calculate time taken in microseconds
             RDK_LOG(RDK_LOG_INFO, LOG_TR69HOSTIF,
                 "[%s:%d] ret: %d, paramName: %s, paramValue: %s, timeTaken: %lld us\n",
                 __FUNCTION__, __LINE__, ret,
                 stMsgData->paramName,
-                stMsgData->paramValue,
+                paramValueStr,
                 timeTaken);
            // Telemetry and debug log if processing time > 5 second (1,000,000 us)
             if (timeTaken > 5000000) {
@@ -224,11 +262,50 @@ int hostIf_SetMsgHandler(HOSTIF_MsgData_t *stMsgData)
         auto endTime = std::chrono::high_resolution_clock::now();
         auto timeTakenset = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
 
+        char paramValueStr[128] = {0};
+        switch (stMsgData->paramtype) {
+        case hostIf_StringType:
+             snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+        break;
+        case hostIf_IntegerType: {
+            int val = 0;
+            memcpy(&val, stMsgData->paramValue, sizeof(val));
+            snprintf(paramValueStr, sizeof(paramValueStr), "%d", val);
+            break;
+        }
+        case hostIf_UnsignedIntType: {
+             unsigned int val = 0;
+             memcpy(&val, stMsgData->paramValue, sizeof(val));
+             snprintf(paramValueStr, sizeof(paramValueStr), "%u", val);
+             break;
+        }
+        case hostIf_BooleanType: {
+             bool val = false;
+             memcpy(&val, stMsgData->paramValue, sizeof(val));
+             snprintf(paramValueStr, sizeof(paramValueStr), "%s", val ? "true" : "false");
+             break;
+        }
+        case hostIf_DateTimeType:
+              snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+              break;
+        case hostIf_UnsignedLongType: {
+            unsigned long val = 0;
+            memcpy(&val, stMsgData->paramValue, sizeof(val));
+            snprintf(paramValueStr, sizeof(paramValueStr), "%lu", val);
+            break;
+        }
+        default:
+            snprintf(paramValueStr, sizeof(paramValueStr), "<unknown or unsupported type>");
+        break;
+        }
+
+
+
         RDK_LOG(RDK_LOG_INFO, LOG_TR69HOSTIF,
                 "[%s:%d] ret: %d, paramName: %s, paramValue: %s, timeTaken: %lld us\n",
                 __FUNCTION__, __LINE__, ret,
                 stMsgData->paramName,
-                stMsgData->paramValue,
+                paramValueStr,
                 timeTakenset);
        // Telemetry and debug log if processing time > 5 seconds (5,000,000 us)
         if (timeTakenset > 5000000) {

--- a/src/hostif/handlers/src/hostIf_msgHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_msgHandler.cpp
@@ -84,6 +84,50 @@ static std::atomic<bool> loggedSet1000Within5Min {false};
 
 #define PARAM_VALUE_STR_SIZE 128
 
+
+void paramValueToString(const HOSTIF_MsgData_t *stMsgData, char *paramValueStr, size_t strSize)
+{
+    if (!stMsgData || !paramValueStr || strSize == 0) {
+        if (paramValueStr && strSize > 0)
+            snprintf(paramValueStr, strSize, "<invalid input>");
+        return;
+    }
+
+    switch (stMsgData->paramtype) {
+        case hostIf_StringType:
+        case hostIf_DateTimeType:
+            snprintf(paramValueStr, strSize, "%s", (const char*)stMsgData->paramValue);
+            break;
+        case hostIf_IntegerType: {
+            int val = 0;
+            memcpy(&val, stMsgData->paramValue, sizeof(val));
+            snprintf(paramValueStr, strSize, "%d", val);
+            break;
+        }
+        case hostIf_UnsignedIntType: {
+            unsigned int val = 0;
+            memcpy(&val, stMsgData->paramValue, sizeof(val));
+            snprintf(paramValueStr, strSize, "%u", val);
+            break;
+        }
+        case hostIf_BooleanType: {
+            bool val = false;
+            memcpy(&val, stMsgData->paramValue, sizeof(val));
+            snprintf(paramValueStr, strSize, "%s", val ? "true" : "false");
+            break;
+        }
+        case hostIf_UnsignedLongType: {
+            unsigned long val = 0;
+            memcpy(&val, stMsgData->paramValue, sizeof(val));
+            snprintf(paramValueStr, strSize, "%lu", val);
+            break;
+        }
+        default:
+            snprintf(paramValueStr, strSize, "<unknown or unsupported type>");
+            break;
+    }
+}
+
 int hostIf_GetMsgHandler(HOSTIF_MsgData_t *stMsgData)
 {
     LOG_ENTRY_EXIT;
@@ -140,44 +184,7 @@ int hostIf_GetMsgHandler(HOSTIF_MsgData_t *stMsgData)
             auto endTime = std::chrono::high_resolution_clock::now();
             auto timeTaken = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
             char paramValueStr[PARAM_VALUE_STR_SIZE] = {0};
-            switch (stMsgData->paramtype) {
-            case hostIf_StringType:
-                snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%s", stMsgData->paramValue);
-                //snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
-                break;
-            case hostIf_IntegerType: {
-                 int val = 0;
-                 memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%d", val);
-                 break;
-            }
-            case hostIf_UnsignedIntType: {
-                 unsigned int val = 0;
-                 memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%u", val);
-                 break;
-            }
-            case hostIf_BooleanType: {
-                 bool val = false;
-                 memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%s", val ? "true" : "false");
-                break;
-            }
-            case hostIf_DateTimeType:
-                 //snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
-                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%s", stMsgData->paramValue);
-                 break;
-            case hostIf_UnsignedLongType: {
-                 unsigned long val = 0;
-                 memcpy(&val, stMsgData->paramValue, sizeof(val));
-                 snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "%lu", val);
-                 break;
-            }
-            default:
-                   snprintf(paramValueStr, PARAM_VALUE_STR_SIZE, "<unknown or unsupported type>");
-                   break;
-            }
-
+            paramValueToString(stMsgData, paramValueStr, sizeof(paramValueStr));
             
 
             // Calculate time taken in microseconds
@@ -267,43 +274,7 @@ int hostIf_SetMsgHandler(HOSTIF_MsgData_t *stMsgData)
         auto timeTakenset = std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime).count();
 
         char paramValueStr[128] = {0};
-        switch (stMsgData->paramtype) {
-        case hostIf_StringType:
-            snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
-        break;
-        case hostIf_IntegerType: {
-            int val = 0;
-            memcpy(&val, stMsgData->paramValue, sizeof(val));
-            snprintf(paramValueStr, sizeof(paramValueStr), "%d", val);
-            break;
-        }
-        case hostIf_UnsignedIntType: {
-             unsigned int val = 0;
-             memcpy(&val, stMsgData->paramValue, sizeof(val));
-             snprintf(paramValueStr, sizeof(paramValueStr), "%u", val);
-             break;
-        }
-        case hostIf_BooleanType: {
-             bool val = false;
-             memcpy(&val, stMsgData->paramValue, sizeof(val));
-             snprintf(paramValueStr, sizeof(paramValueStr), "%s", val ? "true" : "false");
-             break;
-        }
-        case hostIf_DateTimeType:
-              snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
-              break;
-        case hostIf_UnsignedLongType: {
-            unsigned long val = 0;
-            memcpy(&val, stMsgData->paramValue, sizeof(val));
-            snprintf(paramValueStr, sizeof(paramValueStr), "%lu", val);
-            break;
-        }
-        default:
-            snprintf(paramValueStr, sizeof(paramValueStr), "<unknown or unsupported type>");
-        break;
-        }
-
-
+        paramValueToString(stMsgData, paramValueStr, sizeof(paramValueStr));
 
         RDK_LOG(RDK_LOG_INFO, LOG_TR69HOSTIF,
                 "[%s:%d] ret: %d, paramName: %s, paramValue: %s, timeTaken: %lld us\n",

--- a/src/hostif/handlers/src/hostIf_msgHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_msgHandler.cpp
@@ -265,7 +265,7 @@ int hostIf_SetMsgHandler(HOSTIF_MsgData_t *stMsgData)
         char paramValueStr[128] = {0};
         switch (stMsgData->paramtype) {
         case hostIf_StringType:
-             snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+            snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
         break;
         case hostIf_IntegerType: {
             int val = 0;
@@ -286,7 +286,7 @@ int hostIf_SetMsgHandler(HOSTIF_MsgData_t *stMsgData)
              break;
         }
         case hostIf_DateTimeType:
-              snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+              snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
               break;
         case hostIf_UnsignedLongType: {
             unsigned long val = 0;

--- a/src/hostif/handlers/src/hostIf_msgHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_msgHandler.cpp
@@ -140,7 +140,7 @@ int hostIf_GetMsgHandler(HOSTIF_MsgData_t *stMsgData)
             char paramValueStr[128] = {0};
             switch (stMsgData->paramtype) {
             case hostIf_StringType:
-                snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+                snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
                 break;
             case hostIf_IntegerType: {
                  int val = 0;
@@ -161,7 +161,7 @@ int hostIf_GetMsgHandler(HOSTIF_MsgData_t *stMsgData)
                 break;
             }
             case hostIf_DateTimeType:
-                 snprintf(paramValueStr, sizeof(paramValueStr), "%s", stMsgData->paramValue);
+                 snprintf(paramValueStr, sizeof(paramValueStr), "%.*s", (int)sizeof(paramValueStr) - 1, stMsgData->paramValue);
                  break;
             case hostIf_UnsignedLongType: {
                  unsigned long val = 0;


### PR DESCRIPTION
[RDKEMW-5582] -[RDKE] tr69hostif.log contains any garbage data for the paramValue field

Reason for change: Inorder to print the correct value instead of garbage value
Test Procedure: 
Risks: Medium
Priority: P1
Signed-off-by: Vismal S Kumar <ajvismal@yahoo.com>