### PR TITLE
RDKTV-38130-[RDKE_Trials][8.2p2s2]: Increase in "tr69hostif" crash with function "hostIf_WiFi_SSID::get_Device_WiFi_SSID_Fields" and "81598460" fingerprint

### DIFF
--- a/src/hostif/profiles/wifi/Device_WiFi.cpp
+++ b/src/hostif/profiles/wifi/Device_WiFi.cpp
@@ -281,7 +281,7 @@ int hostIf_WiFi::get_Device_WiFi_EnableWiFi(HOSTIF_MsgData_t *stMsgData)
 	        }
 
                 //ASSIGN TO OP HERE
-		cJSON *result = cJSON_GetObjectItem(interface, "isEnabled");
+		cJSON *result = cJSON_GetObjectItem(interface, "enabled");
 		put_boolean(stMsgData->paramValue, result->type);
                 stMsgData->paramtype = hostIf_BooleanType;
                 stMsgData->paramLen=1;

--- a/src/hostif/profiles/wifi/Device_WiFi_EndPoint.cpp
+++ b/src/hostif/profiles/wifi/Device_WiFi_EndPoint.cpp
@@ -309,7 +309,7 @@ int hostIf_WiFi_EndPoint::refreshCache()
 	        }
 
                 //ASSIGN TO OP HERE
-		cJSON *result = cJSON_GetObjectItem(interface, "isEnabled");
+		cJSON *result = cJSON_GetObjectItem(interface, "enabled");
 		Enable = result->type;
 
 		cJSON *state = cJSON_GetObjectItem(jsonObj, "state");

--- a/src/hostif/profiles/wifi/Device_WiFi_SSID.cpp
+++ b/src/hostif/profiles/wifi/Device_WiFi_SSID.cpp
@@ -212,7 +212,7 @@ int hostIf_WiFi_SSID::get_Device_WiFi_SSID_Fields(int ssidIndex)
         	    {
             	        ERR_CHK(rc);
         	    }
-		    cJSON *isEnabled = cJSON_GetObjectItem(interface, "isEnabled");
+		    cJSON *isEnabled = cJSON_GetObjectItem(interface, "enabled");
 		    enable=isEnabled->type;
 		    RDK_LOG (RDK_LOG_INFO, LOG_TR69HOSTIF, "%s: ENABLE = %d \n", __FUNCTION__, enable);
                 }


### PR DESCRIPTION
[RDKE_Trials][8.2p2s2]: Increase in "tr69hostif" crash with function "hostIf_WiFi_SSID::get_Device_WiFi_SSID_Fields" and "81598460" fingerprint

Reason for change:debug
