### PR TITLE
RDK-56291 - [RDKE] Increase L2 Test Coverage For Remote Debugger : Target 80% [ Phase 2 ]

### DIFF
--- a/cov_build.sh
+++ b/cov_build.sh
@@ -11,7 +11,7 @@ cd rfc
 autoreconf -i
 ./configure --enable-rfctool=yes --enable-tr181set=yes --enable-tr69hostif=yes
 cd rfcapi
-make librfcapi_la_CPPFLAGS="-I/usr/include/cjson"
+make librfcapi_la_CPPFLAGS="-I/usr/include/cjson -DUSE_IARMBUS"
 make install
 cd ../tr181api
 cp /usr/include/cjson/cJSON.h  ./


### PR DESCRIPTION
Reason for change: Increase L2 Test Coverage For Remote Debugger
Test Procedure: Focused Regression
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)