### PR TITLE
RDKEMW-7135 : Gamepad RFC is not enabled by default

### DIFF
--- a/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model/data-model-generic.xml
@@ -338,7 +338,7 @@
       <parameter base="Enable" access="readWrite" notification="0" maxNotification="2" >
        <syntax>
          <boolean/>
-          <default type="factory" value="false"/>
+          <default type="factory" value="true"/>
        </syntax>
       </parameter>
     </object>


### PR DESCRIPTION
Reason for change: Set Gamepad RFC as True

Test Procedure: verify the steps in Ticket description
Risks: Medium
Priority: P2