### PR TITLE
RDKEMW-4759 - Review and Analyze the RRD Static Profiles for RDK devices

### DIFF
--- a/src/hostif/handlers/src/hostIf_DeviceClient_ReqHandler.cpp
+++ b/src/hostif/handlers/src/hostIf_DeviceClient_ReqHandler.cpp
@@ -486,6 +486,10 @@ int DeviceClientReqHandler::handleGetMsg(HOSTIF_MsgData_t *stMsgData)
         {
             ret = pIface->get_Device_DeviceInfo_X_RDKCENTRAL_COM_BootStatus(stMsgData);
         }
+        else if(strcasecmp(stMsgData->paramName,"Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.RDKRemoteDebugger.getProfileData") == 0)
+	    {
+            ret = pIface->get_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggergetProfileData(stMsgData);
+	    }
         else if (strcasecmp(stMsgData->paramName,"Device.DeviceInfo.X_RDKCENTRAL-COM_PreferredGatewayType") == 0)
         {
             ret = pIface->get_Device_DeviceInfo_X_RDKCENTRAL_COM_PreferredGatewayType(stMsgData);

--- a/src/hostif/parodusClient/waldb/data-model-generic.xml
+++ b/src/hostif/parodusClient/waldb/data-model-generic.xml
@@ -637,6 +637,11 @@
           <default type="factory" value="true"/>
         </syntax>
       </parameter>
+      <parameter base="getProfileData" access="readOnly" notification="0" maxNotification="2" >
+        <syntax>
+          <string/>
+        </syntax>
+      </parameter>
       <parameter base="IssueType" access="readWrite" notification="0" maxNotification="2" >
         <syntax>
           <string/>

--- a/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.cpp
+++ b/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.cpp
@@ -4188,6 +4188,127 @@ int hostIf_DeviceInfo::set_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggerI
     return retVal;
 }
 
+int hostIf_DeviceInfo::get_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggergetProfileData(HOSTIF_MsgData_t *stMsgData)
+{
+    stMsgData->paramtype = hostIf_StringType;
+    int retStatus = NOK;
+    const char *filename = "/etc/rrd/remote_debugger.json";
+    FILE *fp = nullptr;
+    char *fileBuf = nullptr;
+    long fileSz = 0;
+    size_t bytesRead = 0;
+    cJSON *root = nullptr;
+    cJSON *filtered = nullptr;
+    char *outStr = nullptr;
+    size_t outLen = 0;
+    RDK_LOG(RDK_LOG_TRACE1, LOG_TR69HOSTIF, "[%s] Entering …\n", __FUNCTION__);
+    fp = fopen(filename, "rb");
+    if (!fp) 
+    {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Cannot open %s\n", __FUNCTION__, filename);
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+        return retStatus;
+    }
+    if (fseek(fp, 0L, SEEK_END) != 0) 
+    {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] fseek failed\n", __FUNCTION__);
+        fclose(fp);
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+        return retStatus;
+    }
+    fileSz = ftell(fp);
+    rewind(fp);
+    if (fileSz < 0) 
+    {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] fileSz is negative, Returning....\n", __FUNCTION__);
+        fclose(fp);
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+        return retStatus;
+    }
+    fileBuf = (char*)malloc((size_t)fileSz + 1);
+    if (!fileBuf) 
+    {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] malloc(%ld) failed\n", __FUNCTION__, fileSz + 1);
+        fclose(fp);
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+        return retStatus;
+    }
+    bytesRead = fread(fileBuf, 1U, (size_t)fileSz, fp);
+    fileBuf[bytesRead] = '\0';
+    fclose(fp); fp = nullptr;
+    root = cJSON_Parse(fileBuf);
+    if (!root) 
+    {
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] JSON parse error: %s\n", __FUNCTION__, cJSON_GetErrorPtr());
+        free(fileBuf);
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+        return retStatus;
+    }
+    filtered = cJSON_CreateObject();
+    if (!filtered) 
+    {
+        free(fileBuf);
+        cJSON_Delete(root);
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+        return retStatus;
+    }
+
+    for (cJSON *top = root->child; top; top = top->next) 
+    {
+        if (top->type != cJSON_Object) 
+	{
+            continue;
+        }
+        cJSON *arr = cJSON_CreateArray();
+        if (!arr) 
+	{
+            free(fileBuf);
+            cJSON_Delete(root);
+            cJSON_Delete(filtered);
+            RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+            return retStatus;
+        }
+        for (cJSON *sub = top->child; sub; sub = sub->next) 
+	{
+            cJSON_AddItemToArray(arr, cJSON_CreateString(sub->string));
+        }
+        if (cJSON_GetArraySize(arr) > 0) 
+	{
+            cJSON_AddItemToObject(filtered, top->string, arr);
+        } 
+	else 
+	{
+            cJSON_Delete(arr);
+        }
+    }
+
+    outStr = cJSON_PrintUnformatted(filtered);
+    if (!outStr) 
+    {
+        free(fileBuf);
+        cJSON_Delete(root);
+        cJSON_Delete(filtered);
+        RDK_LOG(RDK_LOG_ERROR, LOG_TR69HOSTIF, "[%s] Leaving with NOK\n", __FUNCTION__);
+        return retStatus;
+    }
+    outLen = strlen(outStr);
+    if (outLen >= sizeof(stMsgData->paramValue)) 
+    {
+        outLen = sizeof(stMsgData->paramValue) - 1;
+    }
+    memcpy(stMsgData->paramValue, outStr, outLen);
+    stMsgData->paramValue[outLen] = '\0';
+    stMsgData->paramLen = outLen;
+    RDK_LOG(RDK_LOG_INFO, LOG_TR69HOSTIF, "[%s] Extracted profile map: %s\n", __FUNCTION__, outStr);
+    retStatus = OK;
+    free(fileBuf);
+    cJSON_Delete(root);
+    cJSON_Delete(filtered);
+    free(outStr);
+    RDK_LOG(RDK_LOG_TRACE1, LOG_TR69HOSTIF, "[%s] Leaving with OK\n", __FUNCTION__);
+    return retStatus;
+}
+
 int hostIf_DeviceInfo::set_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggerWebCfgData (HOSTIF_MsgData_t *stMsgData)
 {
     char *issueStr = NULL;

--- a/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.cpp
+++ b/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.cpp
@@ -4256,7 +4256,7 @@ int hostIf_DeviceInfo::get_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggerg
     for (cJSON *top = root->child; top; top = top->next) 
     {
         if (top->type != cJSON_Object) 
-	{
+	    {
             continue;
         }
         cJSON *arr = cJSON_CreateArray();

--- a/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.h
+++ b/src/hostif/profiles/DeviceInfo/Device_DeviceInfo.h
@@ -1215,6 +1215,7 @@ public:
 
     int set_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggerIssueType(HOSTIF_MsgData_t *);
     int set_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggerWebCfgData(HOSTIF_MsgData_t *);
+    int get_Device_DeviceInfo_X_RDKCENTRAL_COM_RDKRemoteDebuggergetProfileData(HOSTIF_MsgData_t *);
 #endif
 
     /*


### PR DESCRIPTION
Reason for change: Implement rfc parameter for printing rrd available issuetypes in the json
Test Procedure: Verify g
et parameter is working as expected, sanity
Risks: Low
Signed-off-by: Abhinav P V [Abhinav_Valappil@comcast.com](mailto:Abhinav_Valappil@comcast.com)